### PR TITLE
Fixes pausing in live edge on DVR playback.

### DIFF
--- a/src/comscore.js
+++ b/src/comscore.js
@@ -306,7 +306,7 @@ export default class Comscore extends BasePlugin {
 
     // At the end of the playback we've notice there's an unexpected pause event.
     // We won't notify this pause, only these happening at the middle of the playback.
-    // This should not apply when playing end event.
+    // This should not apply on live streams.
     if(this._isLive || Math.ceil(this.player.currentTime) < this.player.duration) {
       this._sendCommand("notifyPause");
 


### PR DESCRIPTION
The plugin was having an issue when trying to pause on the live edge position in a DVR due to a workaround that was meant to only be used in VDO. We've added a condition so this exception is not taken into account when playing live streams.