### PR TITLE
fix(FEC-8216): when running audio only stream the ns_st_ty is video instead of audio

### DIFF
--- a/src/comscore.js
+++ b/src/comscore.js
@@ -452,7 +452,7 @@ export default class Comscore extends BasePlugin {
     const contentMetadataLabels = this._getContentMetadataLabels(relatedContentMetadataObject);
 
     const isLive = this.player.isLive(),
-      isAudio = this.player.config.type == MediaType.AUDIO;
+      isAudio = this.player.config.sources.type == MediaType.AUDIO;
 
     const labelsToCopyFromContentMetadata = [
       'ns_st_pl',


### PR DESCRIPTION
fix the reference to the sources type. should be under `sources` object.