### PR TITLE
fix: Incorrect value in labels ns_st_ws, ns_st_vo, ns_st_br, ns_st_ci, ns_st_ami

### DIFF
--- a/src/comscore.js
+++ b/src/comscore.js
@@ -469,6 +469,7 @@ export default class Comscore extends BasePlugin {
       isAudio = this.player.config.sources.type == MediaType.AUDIO;
 
     const labelsToCopyFromContentMetadata = [
+      'ns_st_ci',
       'ns_st_pl',
       'ns_st_pr',
       'ns_st_ep'
@@ -478,10 +479,6 @@ export default class Comscore extends BasePlugin {
       if(labelName in contentMetadataLabels) {
         advertisementMetadataLabels[labelName] = contentMetadataLabels[labelName];
       }
-    }
-
-    if(advertisementMetadataObject.extraAdData && advertisementMetadataObject.extraAdData.adId) {
-      advertisementMetadataLabels['ns_st_ci'] = advertisementMetadataObject.extraAdData.adId + '';
     }
 
     advertisementMetadataLabels['ns_st_pn'] = "1"; // Current part number of the ad. Always assume part 1.
@@ -514,6 +511,10 @@ export default class Comscore extends BasePlugin {
     } else {
       // This should never happen.
       advertisementMetadataLabels['ns_st_ad'] = 1;
+    }
+
+    if(advertisementMetadataObject.extraAdData && advertisementMetadataObject.extraAdData.adId) {
+      advertisementMetadataLabels['ns_st_ami'] = advertisementMetadataObject.extraAdData.adId + '';
     }
 
     if(advertisementMetadataObject.extraAdData && advertisementMetadataObject.extraAdData.adSystem) {


### PR DESCRIPTION
* Label ns_st_ws – This parameter appears only after moving the first time to full screen mode
* Label ns_st_vo - This label will only appear only after there has been a volume change in the player, but at the beginning is won't appear at all. It is expected that the label always is there.
* When live stream failed (not broadcasting) there are Play and End events.
* ns_st_br value is always zero, with auto value or even when changing manually bitrate because we are reporting the videoTrackChanged incorrectly. That event, is not an event for the video track language change but to report when there's a video quality change (720p, HD, etc...).
* ns_st_ci value is reporting the wrong value. Instead, we should report the content ID (the value from the content's label ns_st_ci. And then report the current value in the label ns_st_ami.
* Fixes the metadata prefix objects that are used in the labelmapping feature.