### PR TITLE
chore: align the dist files name with other playkit plugins

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ if (PROD) {
 module.exports = {
   context: __dirname + "/src",
   entry: {
-    "playkit-js-comscore": "index.js"
+    "playkit-comscore": "index.js"
   },
   output: {
     path: __dirname + "/dist",


### PR DESCRIPTION
changing the min files from `playkit-js-comscore.js(.map)` to `playkit-comscore.js(.map)`