### PR TITLE
fix: Reported playback rate.

### DIFF
--- a/src/comscore.js
+++ b/src/comscore.js
@@ -324,7 +324,7 @@ export default class Comscore extends BasePlugin {
   }
 
   _onRateChange(): void {
-    const playbackRate = this.player.playbackRate;
+    const playbackRate = this.player.playbackRate * 100;
 
     this._gPlugin.notifyChangePlaybackRate(playbackRate);
   }


### PR DESCRIPTION
Playback rate is not properly reported by the plugin to the Streaming Analytics library. When playback is normal rate it is reporting as `1` instead of the expected value `100`.