### PR TITLE
feat(FEC-8329): support require-js imports

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,8 +30,9 @@ module.exports = {
   output: {
     path: __dirname + "/dist",
     filename: '[name].js',
-    library: ["playkit", "Comscore"],
+    library: ['KalturaPlayer', 'plugins', 'comscore'],
     libraryTarget: "umd",
+    umdNamedDefine: true,
     devtoolModuleFilenameTemplate: "./comscore/[resource-path]"
   },
   devtool: 'source-map',


### PR DESCRIPTION
require js requires(no pun intended :-)) a named module definition, need to add `umdNamedDefine` config to webpack.

Also aligned the root import of the library to the player plugins convention.