### PR TITLE
chore: manage version of plugin via package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playkit-js-comscore",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "main": "dist/playkit-js-comscore.js",
   "scripts": {
     "clean": "rm -rf ./dist",

--- a/src/comscore.js
+++ b/src/comscore.js
@@ -22,7 +22,6 @@ export default class Comscore extends BasePlugin {
 
   _gPluginPromise: Promise<*>;
 
-  static PLUGIN_VERSION = "2.0.0";
   static PLUGIN_PLATFORM_NAME = "kalturav3";
 
   /**
@@ -77,7 +76,7 @@ export default class Comscore extends BasePlugin {
 
       this._trackEventMonitor('Configured publisherId', pluginConfig['publisherId']);
 
-      this._gPlugin = new ns_.StreamingAnalytics.Plugin(pluginConfig, Comscore.PLUGIN_PLATFORM_NAME, Comscore.PLUGIN_VERSION, window.KalturaPlayer.VERSION, {
+      this._gPlugin = new ns_.StreamingAnalytics.Plugin(pluginConfig, Comscore.PLUGIN_PLATFORM_NAME, __VERSION__, window.KalturaPlayer.VERSION, {
         position: this._getCurrentPosition.bind(this)
       });
 


### PR DESCRIPTION
manage the plugin version via package.json.
This will allow the version to progress according to development with the `standard-release` process

As the initial version was set to 2.0.0 then the version will change MAJOR.