### PR TITLE
fix(FEC-8265): 'playing' event is not sent after seek in IE/Edge

### DIFF
--- a/src/comscore.js
+++ b/src/comscore.js
@@ -112,7 +112,6 @@ export default class Comscore extends BasePlugin {
     let listeners = {
       [this.player.Event.SOURCE_SELECTED]: this._onSourceSelected,
       [this.player.Event.ERROR]: this._onError,
-      [this.player.Event.PLAYING]: this._onPlaying,
       [this.player.Event.SEEKING]: this._onSeeking,
       [this.player.Event.PAUSE]: this._onPause,
       [this.player.Event.ENDED]: this._onEnded,
@@ -266,6 +265,10 @@ export default class Comscore extends BasePlugin {
     if (newState.type === this.player.State.BUFFERING) {
       this._sendCommand('notifyBufferStart');
       this._isPlaybackLifeCycleStarted = true;
+    }
+
+    if (newState.type === this.player.State.PLAYING) {
+      this._onPlaying();
     }
   }
 


### PR DESCRIPTION
IE is not firing 'playing' event after seeked (chrome does).

So - I considered the player state for playing instead of the html5 event which is less consistent.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
