### PR TITLE
fix(FEC-9062): comscore fails with IMA DAI

### DIFF
--- a/src/comscore.js
+++ b/src/comscore.js
@@ -518,10 +518,9 @@ export default class Comscore extends BasePlugin {
       if (advertisementMetadataObject.ad.title) {
         advertisementMetadataLabels['ns_st_amt'] = advertisementMetadataObject.ad.title;
       }
-    }
-
-    if (advertisementMetadataObject.extraAdData && advertisementMetadataObject.extraAdData.adSystem) {
-      advertisementMetadataLabels['ns_st_ams'] = advertisementMetadataObject.extraAdData.adSystem.toLowerCase();
+      if (advertisementMetadataObject.ad.system) {
+        advertisementMetadataLabels['ns_st_amt'] = advertisementMetadataObject.ad.system;
+      }
     }
 
     return advertisementMetadataLabels;


### PR DESCRIPTION
### Description of the Changes

* In IMA-DAI plugin AD_LOADED event is fired after AD_BREAK_START.
Reading the ad type from AD_BREAK_START payload is correct in any plugin.
* Get the ad data from the new ad event payload and api.
* Use player enums


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
